### PR TITLE
Waveshare 3.2 inch screen support

### DIFF
--- a/gles2.cpp
+++ b/gles2.cpp
@@ -3,6 +3,12 @@
 #include <unistd.h>
 #ifndef _WIN32
 #include <iostream>
+#ifdef USE_2ND_FRAMEBUFFER
+#include <fcntl.h>
+#include <linux/fb.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#endif
 #include <SDL.h>
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
@@ -264,7 +270,7 @@ Window::Window()
         throw Exception("Cannot initialize secondary framebuffer memory mapping");
     }
 
-    vc_dispmanx_rect_set(&dispmanRect, 0, 0, vinfo.xres, vinfo.yres);
+    vc_dispmanx_rect_set(&dispmanRect, 0, 0, vInfo.xres, vInfo.yres);
 #endif
 
     dispmanElement = vc_dispmanx_element_add(dispmanUpdate, dispmanDisplay, 0, &dstRect, 0, &srcRect,
@@ -424,8 +430,8 @@ bool Window::SwapBuffers()
 #else
     bool swapResult = ::SwapBuffers(hDC);
 #endif
-    vc_dispmanx_snapshot(dispmanDisplay, dispmanResource, 0);
-    vc_dispmanx_resource_read_data(dispmanResource, dispmanRect, framebuffer, fbLineSize);
+    vc_dispmanx_snapshot(dispmanDisplay, dispmanResource, (DISPMANX_TRANSFORM_T)0);
+    vc_dispmanx_resource_read_data(dispmanResource, &dispmanRect, framebuffer, fbLineSize);
 
     return swapResult;
 }

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-FLAGS = -Wall -O3 -fexceptions -fpermissive -fno-strict-aliasing
+FLAGS = -Wall -O3 -fexceptions -fpermissive -fno-strict-aliasing -DUSE_2ND_FRAMEBUFFER
 INCLUDES = -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux -I/usr/include/SDL
 LD_BCM_LIBS_PATH = -L/opt/vc/lib
 LIBS = -lbcm_host -lGLESv2 -lEGL -lSDL -lpthread

--- a/makefile
+++ b/makefile
@@ -1,10 +1,20 @@
-FLAGS = -Wall -O3 -fexceptions -fpermissive -fno-strict-aliasing -DUSE_2ND_FRAMEBUFFER
+FLAGS = -Wall -O3 -fexceptions -fpermissive -fno-strict-aliasing
 INCLUDES = -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux -I/usr/include/SDL
-LD_BCM_LIBS_PATH = -L/opt/vc/lib
-LIBS = -lbcm_host -lGLESv2 -lEGL -lSDL -lpthread
+BRCM_LIBS_PATH = -L/opt/vc/lib
+LIBS = -lbcm_host -lSDL -lpthread
+
+ifeq ($(TFT_OUTPUT), 1)
+	FLAGS += -DTFT_OUTPUT
+endif
+
+ifneq ($(OLD_BRCM_LIB), 1)
+	LIBS += -lbrcmEGL -lbrcmGLESv2
+else
+	LIBS += -lEGL -lGLESv2
+endif
 
 all:
-	g++ $(FLAGS) $(INCLUDES) $(LD_BCM_LIBS_PATH) $(LIBS) -o gles2 gles2.cpp
+	g++ $(FLAGS) $(INCLUDES) $(BRCM_LIBS_PATH) $(LIBS) -o gles2 gles2.cpp
 
 clean:
 	rm ./gles2


### PR DESCRIPTION
Added TFT screens (framebuffer copying) and Raspian Stretch support.

To run on older raspbian releases compile with:
`make all OLD_BRCM_LIB=1`

Tu compile with TFT screen support:
`make all TFT_OUTPUT=1`